### PR TITLE
fix: update css selectors for new character section in subject page

### DIFF
--- a/app/src/main/java/soko/ekibun/bangumi/api/bangumi/bean/Subject.kt
+++ b/app/src/main/java/soko/ekibun/bangumi/api/bangumi/bean/Subject.kt
@@ -352,23 +352,26 @@ data class Subject(
                                 subtitle == "角色介绍" -> {
                                     saxTag = SaxTag.CHARACTOR
                                     subject.crt = doc.select("li")?.map {
-                                        val a = it.selectFirst("a.avatar")
+                                        val titleLink = it.selectFirst("a.title")
+                                        val name = titleLink?.text() ?: ""
+                                        val imageLink = it.selectFirst("a.thumbTip")
+                                        val nameCn = imageLink?.attr("title") ?: name
                                         Character(
                                             id = Regex("""/character/([0-9]*)""").find(
-                                                a?.attr("href") ?: ""
+                                                imageLink?.attr("href") ?: ""
                                             )?.groupValues?.get(1)?.toIntOrNull() ?: 0,
-                                            name = a?.text() ?: "",
-                                            name_cn = it.selectFirst(".info .tip")?.text() ?: "",
+                                            name,
+                                            name_cn = nameCn,
                                             role_name = it.selectFirst(".info .badge_job_tip")?.text() ?: "",
-                                            image = Bangumi.parseImageUrl(a.selectFirst("span.avatarNeue")),
-                                            comment = it.selectFirst("small.fade")?.text()
+                                            image = Bangumi.parseImageUrl(imageLink.selectFirst("span.avatarNeue")),
+                                            comment = it.selectFirst("small.primary")?.text()
                                                 ?.trim('(', '+', ')')?.toIntOrNull() ?: 0,
-                                            actors = it.select("a[rel=\"v:starring\"]").map { psn ->
+                                            actors = it.select("p.badge_actor a").map { actorNameLink ->
                                                 Person(
                                                     id = Regex("""/person/([0-9]*)""").find(
-                                                        psn.attr("href") ?: ""
+                                                        actorNameLink.attr("href") ?: ""
                                                     )?.groupValues?.get(1)?.toIntOrNull() ?: 0,
-                                                    name = psn.text() ?: ""
+                                                    name = actorNameLink.text() ?: ""
                                                 )
                                             })
                                     }


### PR DESCRIPTION
Update CSS selectors for parsing new character section in subject page

HTML for new Character section looks like:

```html
<li class="item clearit">
  <a href="/character/3010" title="陀古萨" class="thumbTip">
    <span
      class="avatarNeue avatarCoverPortrait avatarTop"
      style="background-image: url('//lain.bgm.tv/pic/crt/m/12/a0/3010_crt_aH961.jpg');"
    ></span>
  </a>
  <p class="title">
    <a href="/character/3010" class="title">トグサ</a>
  </p>
  <div class="info">
    <span class="badge_job_tip">配角</span
    ><small class="primary"> (+20) </small>
    <p
      class="badge_actor"
      attr-rlt-type="0"
      att-rlt-type-name="CV"
      attr-rlt-primary="1"
    >
      <span class="tip_i">CV</span>
      <a href="/person/3914">山寺宏一</a>
    </p>
    <p
      class="badge_actor"
      attr-rlt-type="5"
      att-rlt-type-name="英配"
      attr-rlt-primary=""
    >
      <span class="tip_i">英配</span>
      <a href="/person/25896">Crispin Freeman</a>
    </p>
  </div>
</li>
```