### PR TITLE
fix: 修复条目吐槽详情页的css选择器，区分条目吐槽与单纯吐槽，使得时间线页面条目吐槽可以点进关联条目，在爬取吐槽关联封面时排除表情

### DIFF
--- a/app/src/main/java/soko/ekibun/bangumi/api/bangumi/bean/Say.kt
+++ b/app/src/main/java/soko/ekibun/bangumi/api/bangumi/bean/Say.kt
@@ -88,6 +88,7 @@ data class Say(
                             user.avatar = user.avatar ?: "https://api.bgm.tv/v0/users/${user.username}/avatar?type=large"
                             say.user = user
                             say.message = doc.selectFirst(".statusContent .text")?.html()
+                                        ?: doc.selectFirst(".statusContent .comment")?.html()
                             say.time = doc.selectFirst(".statusContent .date")?.text()
                             withContext(Dispatchers.Main) { onUpdateSay(SayReply(say.user, say.message ?: "", 0)) }
                         }

--- a/app/src/main/java/soko/ekibun/bangumi/api/bangumi/bean/TimeLine.kt
+++ b/app/src/main/java/soko/ekibun/bangumi/api/bangumi/bean/TimeLine.kt
@@ -116,7 +116,7 @@ class TimeLine(override val isHeader: Boolean) : SectionEntity {
                             collectStar = Regex("""stars([0-9]*)""").find(
                                 item.selectFirst(".starlight")?.outerHtml() ?: ""
                             )?.groupValues?.get(1)?.toIntOrNull() ?: 0,
-                            thumbs = item.select("$cssInfo img").map {
+                            thumbs = item.select(".cover img").map {//排除表情
                                 val url = it.parent().attr("href")
                                 TimeLineItem.ThumbItem(
                                     image = Bangumi.parseImageUrl(it),

--- a/app/src/main/java/soko/ekibun/bangumi/ui/main/fragment/home/fragment/timeline/TimeLineAdapter.kt
+++ b/app/src/main/java/soko/ekibun/bangumi/ui/main/fragment/home/fragment/timeline/TimeLineAdapter.kt
@@ -101,6 +101,9 @@ class TimeLineAdapter(data: MutableList<TimeLine>? = null) :
             }
         }
 
+        val isPureSay = item.t?.let { t -> //新增细分来判断是单纯的吐槽还是条目吐槽,判断条件：是否有条目图片
+            t.say != null && t.thumbs.isEmpty()
+        } ?: false
         holder.itemView.item_layout.isClickable = item.t?.say != null
         holder.itemView.item_dolike.visibility = if(holder.itemView.item_layout.isClickable) View.VISIBLE else View.INVISIBLE
         holder.itemView.item_dolike.setOnClickListener { v ->
@@ -150,7 +153,7 @@ class TimeLineAdapter(data: MutableList<TimeLine>? = null) :
         //action
         holder.itemView.item_action.text = HtmlUtil.html2span(item.t?.action ?: "")
         holder.itemView.item_action.movementMethod =
-            if (holder.itemView.item_layout.isClickable) null else LinkMovementMethod.getInstance()
+            if (isPureSay) null else LinkMovementMethod.getInstance()
         //del
         holder.itemView.item_del.visibility = if (item.t?.delUrl.isNullOrEmpty()) View.INVISIBLE else View.VISIBLE
         holder.itemView.item_del.setOnClickListener {


### PR DESCRIPTION
fix: 修复条目吐槽详情页的css选择器，区分条目吐槽与单纯吐槽，使得时间线页面条目吐槽可以点进关联条目（点击标题的判定好像有点严格），在爬取吐槽关联封面时排除表情